### PR TITLE
Potential fix for code scanning alert no. 46: Uncontrolled data used in path expression

### DIFF
--- a/django/views/static.py
+++ b/django/views/static.py
@@ -42,7 +42,9 @@ def serve(request, path, document_root=None, show_indexes=False):
     ``static/directory_index.html``.
     """
     path = posixpath.normpath(path).lstrip("/")
-    fullpath = Path(safe_join(document_root, path))
+    fullpath = Path(safe_join(document_root, path)).resolve()
+    if not str(fullpath).startswith(str(Path(document_root).resolve())):
+        raise Http404(_("“%(path)s” is not allowed") % {"path": fullpath})
     if fullpath.is_dir():
         if show_indexes:
             return directory_index(path, fullpath)


### PR DESCRIPTION
Potential fix for [https://github.com/slowedcodinganai/django/security/code-scanning/46](https://github.com/slowedcodinganai/django/security/code-scanning/46)

To fix the problem, we need to ensure that the constructed `fullpath` is within the `document_root` directory. This can be achieved by normalizing the path and then checking that the normalized path starts with the `document_root`. This approach will prevent directory traversal attacks by ensuring that the user cannot access files outside the intended directory.

1. Normalize the `fullpath` using `os.path.normpath`.
2. Check that the normalized `fullpath` starts with the `document_root`.
3. Raise an exception if the check fails.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
